### PR TITLE
strm keyword changed to stream from Python 2.7

### DIFF
--- a/project/base_settings.py
+++ b/project/base_settings.py
@@ -107,12 +107,12 @@ LOGGING = {
         'stdout': {
             'level':'INFO',
             'class':'logging.StreamHandler',
-            'strm': sys.stdout
+            'stream': sys.stdout
         },
         'stderr': {
             'level':'ERROR',
             'class':'logging.StreamHandler',
-            'strm': sys.stderr
+            'stream': sys.stderr
         },
     },
     'loggers': {


### PR DESCRIPTION
Fixes logging error I was seeing building from develop locally.