### PR TITLE
uw-django-saml2 needs PersistentRemoteUserMiddleware

### DIFF
--- a/project/base_settings.py
+++ b/project/base_settings.py
@@ -19,8 +19,8 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.RemoteUserMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddlewarce',
+    'django.contrib.auth.middleware.PersistentRemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
Else you lose REMOTE_USER as soon as you hit an unauthenticated view.