### PR TITLE
Allows all hosts on localdev and only required 3 in the cluster

### DIFF
--- a/project/base_settings/common.py
+++ b/project/base_settings/common.py
@@ -5,7 +5,7 @@ import socket
 import logging
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
- 
+
 if all([os.getenv('CLUSTER_CNAME'), os.getenv('HOSTNAME')]):
     ALLOWED_HOSTS = [
         os.getenv('CLUSTER_CNAME'),                     # External hostname

--- a/project/base_settings/common.py
+++ b/project/base_settings/common.py
@@ -1,10 +1,19 @@
 from django.core.management.utils import get_random_secret_key
 import os
 import sys
+import socket
 import logging
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-
+ 
+if all([os.getenv('CLUSTER_CNAME'), os.getenv('HOSTNAME')]):
+    ALLOWED_HOSTS = [
+        os.getenv('CLUSTER_CNAME'),                     # External hostname
+        os.getenv('HOSTNAME'),                          # Internal hostname
+        socket.gethostbyname(os.getenv('HOSTNAME')),    # IP
+    ]
+else:
+    ALLOWED_HOSTS = ['*']
 
 if os.getenv('ENV', 'localdev') == 'localdev':
     SECRET_KEY = os.getenv('DJANGO_SECRET', get_random_secret_key())
@@ -61,7 +70,7 @@ elif os.getenv('DB', 'sqlite3') == 'mysql':
             'PASSWORD': os.getenv('DATABASE_PASSWORD', None),
         }
     }
-elif os.getenv('DB', 'sqlite3') == 'postgres':
+elif os.getenv('DB', 'sqhostnameslite3') == 'postgres':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',

--- a/project/base_settings/common.py
+++ b/project/base_settings/common.py
@@ -12,11 +12,10 @@ if all([os.getenv('CLUSTER_CNAME'), os.getenv('HOSTNAME')]):
         os.getenv('HOSTNAME'),                          # Internal hostname
         socket.gethostbyname(os.getenv('HOSTNAME')),    # IP
     ]
-else:
-    ALLOWED_HOSTS = ['*']
 
 if os.getenv('ENV', 'localdev') == 'localdev':
     SECRET_KEY = os.getenv('DJANGO_SECRET', get_random_secret_key())
+    ALLOWED_HOSTS = ['*']
 else:
     SECRET_KEY = os.getenv('DJANGO_SECRET', None)
 

--- a/project/base_settings/common.py
+++ b/project/base_settings/common.py
@@ -69,7 +69,7 @@ elif os.getenv('DB', 'sqlite3') == 'mysql':
             'PASSWORD': os.getenv('DATABASE_PASSWORD', None),
         }
     }
-elif os.getenv('DB', 'sqhostnameslite3') == 'postgres':
+elif os.getenv('DB', 'sqlite3') == 'postgres':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
`ALLOWED_HOSTS` can be defined in the base settings file bases on environment variables present in all our deploys.

`os.getenv('CLUSTER_CNAME')`: Allow access though the dns
`os.getenv('HOSTNAME')`, `socket.gethostbyname(os.getenv('HOSTNAME'))`: Allow prometheus to access through internal ip/hostname