### PR TITLE
Fixes the node_modules global path resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,3 +105,5 @@ RUN . /app/bin/activate &&\
     npm install nyc -g &&\
     npm install sinon -g &&\
     npm install coveralls -g
+
+ENV NODE_PATH=/app/lib/node_modules


### PR DESCRIPTION
Without this node does not know where the global modules are located since it is not one of the [standard global locations](https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders).

Node will still search in package path so it doesn't break local packages

I am using it in https://github.com/uw-it-aca/myuw/tree/task/node-bundler if you want to see it working