### PR TITLE
Let supervisorctl control supervisord gracefully

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -2,6 +2,8 @@
 file=/var/run/supervisor/supervisor.sock
 chmod=0777
 chown=acait:acait
+username=dummy
+password=dummy
 
 [supervisord]
 nodaemon=true

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -2,8 +2,6 @@
 file=/var/run/supervisor/supervisor.sock
 chmod=0777
 chown=acait:acait
-username=dummy
-password=dummy
 
 [supervisord]
 nodaemon=true
@@ -15,6 +13,9 @@ logfile_maxbytes=0
 
 [supervisorctl]
 serverurl=unix:///var/run/supervisor/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:gunicorn]
 command=/app/bin/gunicorn -c /etc/gunicorn/conf.py -w %(ENV_GUNICORN_WORKERS)s project.wsgi:application


### PR DESCRIPTION
Dropped optional user/pass as they were published in plaintext in the repo, but we could return them.